### PR TITLE
Fix for shell environment issue under windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,13 @@ OpenApi schemas. It is a fork of https://github.com/SchwarzIT/spectral-intellij-
   it manually using
   <kbd>Settings/Preferences</kbd> > <kbd>Plugins</kbd> > <kbd>⚙️</kbd> > <kbd>Install plugin from disk...</kbd>
 
-This plugin it is required to have the spectral CLI installed on your system.
+This plugin it is required to have the spectral CLI installed on your system. For windows it is recommended to
+install the binary without going through Nodejs.
+
+> **Warning** Should you still want to use the spectral package via NodeJs on Windows then
+you must check "Use node package on on Windows" in the plugin settings. This is necessary for the node packages to
+work and will have a performance cost.
+
 If you don't have it installed yet make sure to follow this
 guide: [Installing Spectral](https://docs.stoplight.io/docs/spectral/b8391e051b7d8-installation)
 
@@ -62,17 +68,23 @@ Examples:
 association.
 If it is detected as a plain text (or any other type) it will be ignored.
 
+### Possibility to use file level overrides
+Spectral offers the possibility to add file based overrides as described [here](https://docs.stoplight.io/docs/spectral/293426e270fac-overrides).
+These don't work by default. If you want to make use of them, then you need to check "Use file level overrides" in the plugin settings.
+
+> **Warning** If turned on, this has a important caveat; you need to save the file for the linting output to match your changes again.
+
 <!-- Plugin description end -->
 
 ## Building the plugin
 ### Building
 ```bash
-./gradlew build  
+./gradlew verifyPlugin  
 ```
 
 ### Run compatibility tests
 ```bash
- 
+ ./gradlew buildPlugin  
 ```
 
 ### Run UI tests
@@ -82,12 +94,12 @@ If it is detected as a plain text (or any other type) it will be ignored.
 
 ### Publish new version
 ```bash
-./gradlew publish  
+./gradlew publishPlugin  
 ```
 
 ---
 Plugin based on the [IntelliJ Platform Plugin Template][template].
 
-[template]: https://github.com/JetBrains/intellij-platform-plugin-template
+[template]: https://github.com/JetBrains/intellij-platform-gradle-plugin
 
-[docs:plugin-description]: https://plugins.jetbrains.com/docs/intellij/plugin-user-experience.html#plugin-description-and-presentation
+[docs:plugin-description]: https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin.html

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 pluginGroup=com.lupor.spectral-linter-intellij-plugin
 pluginName=Spectral-Linter
 pluginRepositoryUrl=https://github.com/lupor/spectral-intellij-plugin
-pluginVersion=0.0.8
+pluginVersion=0.0.9
 pluginSinceBuild=223
 pluginUntilBuild=243.*
 platformType=IC

--- a/src/main/kotlin/com/schwarzit/spectralIntellijPlugin/CommandLineExecutor.kt
+++ b/src/main/kotlin/com/schwarzit/spectralIntellijPlugin/CommandLineExecutor.kt
@@ -12,13 +12,11 @@ class CommandLineExecutor {
         private val logger = getLogger()
     }
 
-    fun execute(commandLIne: GeneralCommandLine, timeout: Duration? = null): ProcessOutput {
-        val command = commandLIne.commandLineString
-        val process = commandLIne.createProcess()
-        val handler = OSProcessHandler(process, command, Charsets.UTF_8)
+    fun execute(commandLine: GeneralCommandLine, timeout: Duration? = null): ProcessOutput {
+        val handler = OSProcessHandler(commandLine)
         val output = ProcessOutput()
 
-        logger.debug("Executing command: $command")
+        logger.debug("Executing command: ${handler.commandLine}")
 
         handler.addProcessListener(object : ProcessAdapter() {
             override fun onTextAvailable(event: ProcessEvent, outputType: Key<*>) {
@@ -38,7 +36,7 @@ class CommandLineExecutor {
 
         if (ended) {
             logger.debug("Command successfully executed with exit code ${output.exitCode}")
-            output.exitCode = process.exitValue()
+            output.exitCode = handler.exitCode!!
         } else {
             logger.debug("Command timed out after ${timeout?.toMillis()} ms")
             handler.destroyProcess()

--- a/src/main/kotlin/com/schwarzit/spectralIntellijPlugin/SpectralExternalAnnotator.kt
+++ b/src/main/kotlin/com/schwarzit/spectralIntellijPlugin/SpectralExternalAnnotator.kt
@@ -19,6 +19,7 @@ import org.jetbrains.yaml.psi.YAMLFile
 import java.io.File
 import java.nio.file.Path
 
+
 class SpectralExternalAnnotator : ExternalAnnotator<Pair<PsiFile, Editor>, List<SpectralIssue>>() {
     companion object {
         val logger = getLogger()

--- a/src/main/kotlin/com/schwarzit/spectralIntellijPlugin/SpectralRunner.kt
+++ b/src/main/kotlin/com/schwarzit/spectralIntellijPlugin/SpectralRunner.kt
@@ -79,7 +79,6 @@ class SpectralRunner(private val project: Project) {
             "Cannot read properties of null" to "One of your custom rules in your ruleset may have a null reference",
             "Error running Spectral" to "Something unexpected happened. Validate ruleset and yaml file structure"
         )
-        println(this.environment)
         val output = try {
             executor.execute(this, timeout)
         } catch (e: ExecutionException) {

--- a/src/main/kotlin/com/schwarzit/spectralIntellijPlugin/SpectralRunner.kt
+++ b/src/main/kotlin/com/schwarzit/spectralIntellijPlugin/SpectralRunner.kt
@@ -7,7 +7,6 @@ import com.intellij.openapi.editor.Document
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.SystemInfo
-import com.intellij.openapi.vfs.CharsetToolkit
 import com.schwarzit.spectralIntellijPlugin.settings.ProjectSettingsState
 import kotlinx.serialization.SerializationException
 import java.io.File
@@ -63,7 +62,7 @@ class SpectralRunner(private val project: Project) {
         val commandLine = GeneralCommandLine(command[0])
             .withParameters(command.drop(1))
             .withWorkDirectory(project.basePath)
-            .withCharset(CharsetToolkit.getDefaultSystemCharset())
+            .withCharset(Charsets.UTF_8)
             .withParentEnvironmentType(GeneralCommandLine.ParentEnvironmentType.SYSTEM)
 
         val commandEnv = mapOf("NODE_OPTIONS" to "--no-warnings")

--- a/src/main/kotlin/com/schwarzit/spectralIntellijPlugin/settings/ProjectSettingsConfigurable.kt
+++ b/src/main/kotlin/com/schwarzit/spectralIntellijPlugin/settings/ProjectSettingsConfigurable.kt
@@ -15,6 +15,8 @@ class ProjectSettingsConfigurable(private val project: Project) : Configurable {
 
         settingsComponent.rulesetInput.text = settings.ruleset
         settingsComponent.includedFilesInput.text = settings.includedFiles
+        settingsComponent.useFileOverrides.isSelected = settings.useFileOverrides
+        settingsComponent.useNodePackageWin.isSelected = settings.useNodePackageWin
         return settingsComponent.mainPanel
     }
 
@@ -26,6 +28,8 @@ class ProjectSettingsConfigurable(private val project: Project) : Configurable {
         val settings = project.service<ProjectSettingsState>()
         var modified = settingsComponent.rulesetInput.text != settings.ruleset
         modified = modified || settingsComponent.includedFilesInput.text != settings.includedFiles
+        modified = modified || settingsComponent.useFileOverrides.isSelected != settings.useFileOverrides
+        modified = modified || settingsComponent.useNodePackageWin.isSelected != settings.useNodePackageWin
         return modified
     }
 
@@ -33,6 +37,8 @@ class ProjectSettingsConfigurable(private val project: Project) : Configurable {
         val settings = project.service<ProjectSettingsState>()
         settings.ruleset = settingsComponent.rulesetInput.text
         settings.includedFiles = settingsComponent.includedFilesInput.text
+        settings.useFileOverrides = settingsComponent.useFileOverrides.isSelected
+        settings.useNodePackageWin = settingsComponent.useNodePackageWin.isSelected
     }
 
     override fun getDisplayName(): String {

--- a/src/main/kotlin/com/schwarzit/spectralIntellijPlugin/settings/ProjectSettingsState.kt
+++ b/src/main/kotlin/com/schwarzit/spectralIntellijPlugin/settings/ProjectSettingsState.kt
@@ -19,6 +19,8 @@ class ProjectSettingsState : PersistentStateComponent<ProjectSettingsState> {
         **/*openapi.yml
         **/*openapi.yaml
     """.trimIndent()
+    var useFileOverrides = false
+    var useNodePackageWin = false
 
     override fun getState(): ProjectSettingsState {
         return this

--- a/src/main/kotlin/com/schwarzit/spectralIntellijPlugin/settings/SettingsComponent.kt
+++ b/src/main/kotlin/com/schwarzit/spectralIntellijPlugin/settings/SettingsComponent.kt
@@ -1,5 +1,7 @@
 package com.schwarzit.spectralIntellijPlugin.settings
 
+import com.intellij.ide.HelpTooltip
+import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBTextArea
 import com.intellij.ui.components.JBTextField
@@ -11,13 +13,35 @@ class SettingsComponent {
     val mainPanel: JPanel
     val rulesetInput = JBTextField()
     val includedFilesInput = JBTextArea()
+    val useFileOverrides = JBCheckBox("Use file level overrides", false)
+    val useNodePackageWin = JBCheckBox("Use node package on on Windows", false)
 
     init {
+        val overrideTooltip = """
+            Preserves file names and allows to use <a href="https://docs.stoplight.io/docs/spectral/293426e270fac-overrides">file name
+            based overrides</a>, but comes at a cost. You have to save
+            the file for it to be in sync again with the linting output.
+        """.trimIndent()
+        HelpTooltip()
+            .setDescription(overrideTooltip)
+            .installOn(useFileOverrides)
+
+        val useNodePackageWinTooltip = """
+            Adds workaround for Windows that is required
+            if Spectral was installed via npm. Has a slight 
+            performance overhead. It is recommended to <a href="https://github.com/stoplightio/spectral/releases">use 
+            the binary directly</a> on Windows machines.
+        """.trimIndent()
+        HelpTooltip()
+            .setDescription(useNodePackageWinTooltip)
+            .installOn(useNodePackageWin)
         mainPanel =
             FormBuilder.createFormBuilder()
                 .addComponent(JBLabel("Ruleset"))
                 .addComponent(rulesetInput)
                 .addLabeledComponent(JBLabel("Included path patterns"), includedFilesInput)
+                .addComponent(useFileOverrides)
+                .addComponent(useNodePackageWin)
                 .addComponentFillVertically(JPanel(), 0)
                 .panel
     }


### PR DESCRIPTION
* Removed redundant code in the commandrunner classes
* Added option to add workaround for windows users that are using the node package
* Added section in the readme recommending the binary installation variant of spectral
* Added option to use file-level overrides in spectral rulesets
* Added section in the readme explaining the caveats